### PR TITLE
TodoService

### DIFF
--- a/src/main/java/com/najung/todo/controller/TodoController.java
+++ b/src/main/java/com/najung/todo/controller/TodoController.java
@@ -51,18 +51,6 @@ public class TodoController {
         return ResponseEntity.ok("저장 되었습니다.");
     }
 
-    @Operation(summary = "todo 반복 저장", description = "기존 todo를 기반으로 반복 저장")
-    @PostMapping("/{todoId}/repeat")
-    public ResponseEntity<?> repeatTodo(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long todoId,
-            @RequestBody TodoRequest todoRequest) {
-
-        Long memberId = userDetails.getMember().getId();
-        todoService.saveMultipleTodo(memberId, todoId, todoRequest);
-        return ResponseEntity.ok("저장 되었습니다.");
-    }
-
     @Operation(summary = "todo 수정", description = "로그인한 유저의 특정 todo 수정")
     @PutMapping("/{todoId}")
     public ResponseEntity<?> updateTodo(

--- a/src/main/java/com/najung/todo/domain/Todo.java
+++ b/src/main/java/com/najung/todo/domain/Todo.java
@@ -8,6 +8,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -39,6 +40,14 @@ public class Todo {
     @Column(nullable = true)
     private LocalDateTime dueDate; // 마감일
 
+    @Setter
+    @Column(nullable = false)
+    private LocalDate startDate; // 시작일
+
+    @Setter
+    @Column(nullable = false)
+    private LocalDate endDate; // 종료일
+
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
     @Column(nullable = false, updatable = false)
@@ -52,16 +61,19 @@ public class Todo {
 
     protected Todo() {}
 
-    public Todo(Member member, String content, String complete, String important, LocalDateTime dueDate) {
+    public Todo(Member member, String content, String complete, String important, LocalDate startDate, LocalDate endDate, LocalDateTime dueDate) {
         this.member = member;
         this.content = content;
         this.complete = complete;
         this.important = important;
         this.dueDate = dueDate;
         this.createdAt = LocalDateTime.now();
+        this.startDate = startDate;
+        this.endDate = endDate;
     }
-    public static Todo of(Member member, String content, String complete, String important, LocalDateTime dueDate) {
-        return new Todo(member, content, complete, important, dueDate);
+    public static Todo of(Member member, String content, String complete,
+                          String important, LocalDate startDate, LocalDate endDate,LocalDateTime dueDate) {
+        return new Todo(member, content, complete, important, startDate, endDate, dueDate);
     }
 
     @PreUpdate

--- a/src/main/java/com/najung/todo/dto/TodoDto.java
+++ b/src/main/java/com/najung/todo/dto/TodoDto.java
@@ -14,14 +14,19 @@ public record TodoDto(
         String important,
         LocalDateTime createdAt,
         LocalDateTime modifiedAt,
+        LocalDate startDate,
+        LocalDate endDate,
         LocalDateTime dueDate
-) {
-    public static TodoDto of(Long id, MemberDto memberDto, String content, String complete, String important, LocalDateTime dueDate) {
-        return new TodoDto(id, memberDto, content, complete, important, LocalDateTime.now(), null, dueDate);
+        ) {
+    public static TodoDto of(Long id, MemberDto memberDto, String content, String complete,
+                             String important, LocalDate startDate, LocalDate endDate, LocalDateTime dueDate)
+    {
+        return new TodoDto(id, memberDto, content, complete, important, LocalDateTime.now(), null, startDate, endDate, dueDate);
     }
 
-    public static TodoDto of(MemberDto memberDto, String content, String complete, String important, LocalDateTime dueDate) {
-        return new TodoDto(null, memberDto, content, complete, important, LocalDateTime.now(), null, dueDate);
+    public static TodoDto of(MemberDto memberDto, String content, String complete,
+                             String important, LocalDate startDate, LocalDate endDate, LocalDateTime dueDate) {
+        return new TodoDto(null, memberDto, content, complete, important, LocalDateTime.now(),null, startDate, endDate, dueDate);
     }
 
     public static TodoDto from(Todo entity) {
@@ -33,6 +38,8 @@ public record TodoDto(
                 entity.getImportant(),
                 entity.getCreatedAt(),
                 entity.getModifiedAt() != null ? entity.getModifiedAt() : null,
+                entity.getStartDate(),
+                entity.getEndDate(),
                 entity.getDueDate()
         );
     }
@@ -43,6 +50,8 @@ public record TodoDto(
                 content,
                 complete,
                 important,
+                startDate,
+                endDate,
                 dueDate
         );
     }

--- a/src/main/java/com/najung/todo/dto/request/TodoRequest.java
+++ b/src/main/java/com/najung/todo/dto/request/TodoRequest.java
@@ -15,15 +15,17 @@ public record TodoRequest(
         String complete,
         @Schema(description = "할 일의 우선 순위", example = "L or M or H")
         String important,
-        @Schema(description = "반복 횟수", example = "Y or N")
-        int count,
+        @Schema(description = "시작일", example = "2024-09-09")
+        LocalDate startDate,
+        @Schema(description = "종료일", example = "2024-09-09")
+        LocalDate endDate,
         @Schema(description = "마감일", example = "2024-09-09")
         LocalDateTime dueDate
 ) {
 
 
-    public static TodoRequest of(String content, String complete, String important, LocalDateTime dueDate, int count){
-        return new TodoRequest(content, complete, important, count, dueDate);
+    public static TodoRequest of(String content, String complete, String important,LocalDate startDate, LocalDate endDate, LocalDateTime dueDate){
+        return new TodoRequest(content, complete, important, startDate, endDate, dueDate);
     }
 
 
@@ -34,6 +36,8 @@ public record TodoRequest(
                 content != null ? content : req.content(),
                 complete != null ? complete : req.complete(),
                 important!= null ? important : req.important(),
+                startDate != null ? startDate : req.startDate(),
+                endDate != null ? endDate : req.endDate(),
                 dueDate != null ? dueDate : req.dueDate()
         );
     }

--- a/src/main/java/com/najung/todo/service/TodoService.java
+++ b/src/main/java/com/najung/todo/service/TodoService.java
@@ -17,7 +17,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Objects;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -33,87 +34,91 @@ public class TodoService {
     public void saveTodo(Long memberId, TodoRequest todoRequest) {
         Member member = memberRepository.getReferenceById(memberId);
         TodoDto dto = todoRequest.toDto(MemberDto.of(member.getId()), todoRequest);
-        todoRepository.save(dto.toEntity(member));
 
-    }
+        LocalDate startDate = dto.dueDate() != null ? dto.dueDate().toLocalDate() : LocalDate.now();
+        LocalDate endDate = todoRequest.endDate() != null ? todoRequest.endDate() : startDate;
 
-    public void saveMultipleTodo(Long memberId, Long todoId, TodoRequest req) {
-        Todo todo = todoRepository.getReferenceById(todoId);
-        Member member = memberRepository.getReferenceById(memberId);
-        try {
-            /*
-              현재 테스트 코드에서는 todo와 member의 ID 값이 NULL인 문제를 발견
-              이로 인해 if 문이 통과하지 않아 테스트가 계속 실패
-              따라서, 임시로 Objects.equals를 사용하여 null 안전 비교를 진행.
-              추후 문제가 발생할 경우, 해당 로직을 수정할 필요가 있음.
-             */
-            if (Objects.equals(todo.getMember().getId(), member.getId())) {
-                for (int i = 0; i < req.count(); i++) {
-                    TodoRequest req1 = new TodoRequest(
-                            req.content(),
-                            req.complete(),
-                            req.important(),
-                            req.count(),
-                            req.dueDate().plusDays(i + 1)
-                    );
-                    TodoDto dto = req1.toDto(MemberDto.of(member.getId()), req1);
-                    Todo newTodo = dto.toEntity(member);
-                    todoRepository.save(newTodo);
-
-                }
+        if (!startDate.isAfter(endDate)) {
+            for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+                LocalDateTime dueDate = date.atStartOfDay();
+                TodoDto newDto = TodoDto.of(
+                        dto.memberDto(),
+                        dto.content(),
+                        dto.complete(),
+                        dto.important(),
+                        dto.startDate(),
+                        dto.endDate(),
+                        dueDate
+                );
+                todoRepository.save(newDto.toEntity(member));
             }
-        } catch (EntityNotFoundException e) {
-            log.warn("해당 ToDo가 존재하지 않습니다.");
+        } else {
+            throw new IllegalArgumentException("시작일은 종료일보다 이후일 수 없습니다.");
         }
     }
 
+
     @Transactional(readOnly = true)
     public Page<TodoDto> searchTodo(Long memberId, TodoSearchRequest todoSearchRequest, Pageable pageable) {
+        if (memberId == null || memberId <= 0) {
+            throw new IllegalArgumentException("유효하지 않은 사용자 입니다.");
+        }
         return todoQueryRepository.searchTodos(memberId, todoSearchRequest, pageable).map(TodoDto::from);
     }
 
     public void updateTodo(Long memberId, Long todoId, TodoRequest req) {
         try {
-             /*
-              현재 테스트 코드에서는 todo와 member의 ID 값이 NULL인 문제를 발견
-              이로 인해 if 문이 통과하지 않아 테스트가 계속 실패
-              따라서, 임시로 Objects.equals를 사용하여 null 안전 비교를 진행.
-              추후 문제가 발생할 경우, 해당 로직을 수정할 필요가 있음.
-             */
             Todo todo = todoRepository.getReferenceById(todoId);
-            Member member = memberRepository.getReferenceById(memberId);
-            TodoDto dto = req.toDto(MemberDto.of(member.getId()), req);
-            if (Objects.equals(todo.getMember().getId(), member.getId())) {
-                if (dto.complete() != null) todo.setComplete(dto.complete());
-                if (dto.important() != null) todo.setImportant(dto.important());
-                if (dto.content() != null) todo.setContent(dto.content());
-            }
+            checkOwner(todo, memberId);
+
+            TodoDto dto = req.toDto(MemberDto.of(memberId), req);
+
+            if (dto.content() != null) todo.setContent(dto.content());
+            if (dto.complete() != null) todo.setComplete(dto.complete());
+            if (dto.important() != null) todo.setImportant(dto.important());
+
         } catch (EntityNotFoundException e) {
-            log.warn("변경 할 todo-list 가 없습니다. - Request: {}", req);
+            log.warn("수정할 Todo가 존재하지 않습니다. todoId: {}, memberId: {}", todoId, memberId);
         }
     }
+
 
     public void updateDueDate(Long memberId, Long todoId, TodoRequest req) {
         try {
             Todo todo = todoRepository.getReferenceById(todoId);
-            Member member = memberRepository.getReferenceById(memberId);
-            TodoDto dto = req.toDto(MemberDto.of(member.getId()), req);
-            if (todo.getMember().equals(member)) {
-                if (dto.dueDate() != null) todo.setDueDate(dto.dueDate());
+            checkOwner(todo, memberId);
+
+            TodoDto dto = req.toDto(MemberDto.of(memberId), req);
+
+            if (dto.dueDate() != null) {
+                LocalDateTime dueDate = dto.dueDate();
+                LocalDate localDate = dueDate.toLocalDate();
+                todo.setDueDate(dueDate);
+                todo.setStartDate(localDate);
+                todo.setEndDate(localDate);
             }
+
         } catch (EntityNotFoundException e) {
-            log.warn("수정 할 정보가 가 없습니다. - Request: {}", req);
+            log.warn("수정할 Todo가 존재하지 않습니다. todoId: {}, memberId: {}", todoId, memberId);
         }
     }
+
 
     public boolean deleteTodo(Long todoId, Long memberId) {
         int deleteCount = todoRepository.deleteByIdAndMember_Id(todoId, memberId);
         if (deleteCount == 0) {
-            log.warn("삭제할 todo가 없습니다.");
+            log.warn("삭제할 todo가 없습니다. todoId={}, memberId={}", todoId, memberId);
             return false;
         } else {
-            log.info("삭제 성공");
+            log.info("todo 삭제 성공. todoId={}, memberId={}", todoId, memberId);
             return true;
+        }
+    }
+
+
+    private void checkOwner(Todo todo, Long memberId) {
+        if (!todo.getMember().getId().equals(memberId)) {
+            throw new IllegalArgumentException("해당 작업에 대한 권한이 없습니다.");
         }
     }
 

--- a/src/test/java/com/najung/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/najung/todo/service/TodoServiceTest.java
@@ -5,8 +5,11 @@ import com.najung.todo.domain.Todo;
 import com.najung.todo.dto.MemberDto;
 import com.najung.todo.dto.TodoDto;
 import com.najung.todo.dto.request.TodoRequest;
+import com.najung.todo.dto.request.TodoSearchRequest;
 import com.najung.todo.repository.MemberRepository;
+import com.najung.todo.repository.TodoQueryRepository;
 import com.najung.todo.repository.TodoRepository;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,13 +18,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.times;
 
 
 @DisplayName("비지니스 로직 - todo-list")
@@ -29,65 +35,116 @@ import static org.mockito.BDDMockito.*;
 class TodoServiceTest {
 
     @InjectMocks
-    private TodoService sut;
+    private TodoService todoService;
     @Mock
     private TodoRepository todoRepository;
     @Mock
     private MemberRepository memberRepository;
 
-    @DisplayName("유저ID를 받아, 해당 유저가 작성한 todo를 저장")
+    @Mock
+    private TodoQueryRepository todoQueryRepository;
+
+    @DisplayName("시작일과 종료일이 같은 경우, todo 1건 저장된다")
     @Test
-    void givenUserId_whenSearchTodos_thenReturnsTodoList() {
+    void givenSameStartAndEndDate_whenSaveTodo_thenSavesOneTodo() {
         // Given
-        TodoRequest req = createTodoRequest("test", "N", "N", 1, null);
-        Long memberId = 1L;
+        LocalDate today = LocalDate.now();
+        TodoRequest req = createTodoRequest("내용", "N", "H", today, today, null);
         Member member = createMember();
 
-        given(memberRepository.getReferenceById(memberId)).willReturn(member);
+        given(memberRepository.getReferenceById(member.getId())).willReturn(member);
         given(todoRepository.save(any(Todo.class))).willReturn(createTodo());
 
         // When
-        sut.saveTodo(memberId, req);
+        todoService.saveTodo(member.getId(), req);
 
         // Then
         then(todoRepository).should().save(any(Todo.class));
     }
 
-    @DisplayName("todo의 id를 받아 동일 아이템을 반복 등록한다.")
+    @DisplayName("시작일과 종료일이 다를 경우, 날짜 수만큼 todo가 저장된다")
     @Test
-    void givenTodoInfo_whenSaveMultipleTodo_thenSaveTodo() {
+    void givenMultipleDates_whenSaveTodo_thenSavesMultipleTodos() {
         // Given
-        Long memberId = 1L;
-        Long todoId = 1L;
-        LocalDate dueDate = LocalDate.parse("2024-09-06");
+        LocalDate start = LocalDate.of(2024, 9, 1);
+        LocalDate end = LocalDate.of(2024, 9, 3);
 
-        Todo todo = createTodo();
+        TodoRequest req = createTodoRequest("내용", "N", "H", start, end, start.atStartOfDay());
         Member member = createMember();
-        TodoRequest req = createTodoRequest("test", "N", "N", 1, dueDate);
 
-        given(memberRepository.getReferenceById(memberId)).willReturn(member);
-        given(todoRepository.getReferenceById(todoId)).willReturn(todo);
+        given(memberRepository.getReferenceById(member.getId())).willReturn(member);
+        given(todoRepository.save(any(Todo.class))).willReturn(createTodo());
 
         // When
-        sut.saveMultipleTodo(memberId, todoId, req);
-        // Then
-        then(todoRepository).should().save(any(Todo.class));
+        todoService.saveTodo(member.getId(), req);
 
+        // Then
+        then(todoRepository).should(times(3)).save(any(Todo.class));
     }
 
-    @DisplayName("유저ID를 받아, 해당 유저가 작성한 todo-list를 반환 ")
+    @DisplayName("날짜가 없으면 오늘 날짜로 todo 1건 저장된다")
+    @Test
+    void givenNoDates_whenSaveTodo_thenSavesWithToday() {
+        // Given
+        TodoRequest req = createTodoRequest("내용", "N", "H", null, null, null);
+        Member member = createMember();
+
+        given(memberRepository.getReferenceById(member.getId())).willReturn(member);
+        given(todoRepository.save(any(Todo.class))).willReturn(createTodo());
+
+        // When
+        todoService.saveTodo(member.getId(), req);
+
+        // Then
+        then(todoRepository).should().save(any(Todo.class));
+    }
+
+
+    @DisplayName("존재하지 않는 memberId로 저장 시 예외가 발생한다")
+    @Test
+    void givenInvalidMemberId_whenSaveTodo_thenThrowsEntityNotFoundException() {
+        // Given
+        Long invalidMemberId = 999L;
+        TodoRequest req = createTodoRequest("내용2", "N", "H", LocalDate.now(), LocalDate.now(), null);
+
+        given(memberRepository.getReferenceById(invalidMemberId))
+                .willThrow(new EntityNotFoundException("회원 없음"));
+
+        // When & Then
+        assertThrows(EntityNotFoundException.class, () -> {
+            todoService.saveTodo(invalidMemberId, req);
+        });
+    }
+
+    @DisplayName("유저 ID와 검색 조건을 받아 todo 리스트를 조회한다")
     @Test
     void givenTodoInfo_whenSavingTodo_thenSaveTodo() {
         // Given
-        Long memberSno = 1L;
+        Member member = createMember();
         Pageable pageable = Pageable.ofSize(20);
-        given(todoRepository.findByMember_sno(memberSno, pageable)).willReturn(Page.empty());
+        TodoSearchRequest todoSearchRequest = createDefaultSearchRequest();
+        given(todoQueryRepository.searchTodos(member.getId(), todoSearchRequest, pageable)).willReturn(Page.empty());
         // When
-        Page<TodoDto> todos = sut.searchTodo(memberSno, pageable);
+        Page<TodoDto> todos = todoService.searchTodo(member.getId(), todoSearchRequest, pageable);
 
         // Then
-        assertThat(todos).isEmpty();
-        then(todoRepository).should().findByMember_sno(memberSno, pageable);
+        assertDoesNotThrow(() -> {
+            todoService.searchTodo(member.getId(), todoSearchRequest, pageable);
+        });
+    }
+
+    @DisplayName("유효하지 않은 memberId로 조회 시 예외가 발생한다")
+    @Test
+    void givenInvalidMemberId_whenSearchTodo_thenThrowsException() {
+        // Given
+        Long invalidId = 0L;
+        TodoSearchRequest request = createDefaultSearchRequest();
+        Pageable pageable = Pageable.ofSize(10);
+
+        // When & Then
+        assertThrows(IllegalArgumentException.class, () -> {
+            todoService.searchTodo(invalidId, request, pageable);
+        });
     }
 
     @DisplayName("유저의 ID와 todo의 ID를 받아, 해당 유저가 작성한 아이템 한개를 업데이트한다.")
@@ -97,97 +154,201 @@ class TodoServiceTest {
         Todo todo = createTodo();
         Member member = createMember();
         Long todoId = 1L;
-        Long memberId = 1L;
-        TodoRequest req = createTodoRequest("content", "complete", "important", 1, null);
+        TodoRequest req = createTodoRequest("내용2", "N", "H", LocalDate.now(), LocalDate.now(), null);
 
         given(todoRepository.getReferenceById(todoId)).willReturn(todo);
-        given(memberRepository.getReferenceById(memberId)).willReturn(member);
+        given(memberRepository.getReferenceById(member.getId())).willReturn(member);
 
         // When
-        sut.updateTodo(todoId, memberId, req);
+        todoService.updateTodo(todoId, member.getId(), req);
         // Then
         then(todoRepository).should().getReferenceById(todoId);
 
     }
 
-    @DisplayName("todo의 ID를 받아, 해당 유저가 작성한 아이템 한개를 삭제 한다.")
+    @DisplayName("Todo의 작성자 ID와 요청자의 ID가 다르면 예외가 발생한다")
     @Test
-    void givenTodoId_whenDeleteTodo_thenDeleteTo() {
+    void givenMismatchedMemberId_whenUpdateTodo_thenThrowsException() {
         // Given
-        Long todoId = 1L;
-        Long memberId = 1L;
+        Member originalWriter = createMember();
+        Member mismatchMember = createMember(2L);
 
-        willReturn(1).given(todoRepository).deleteByIdAndMember_Sno(todoId, memberId);
+        Todo todo = createTodo(1L, originalWriter);
 
-        // When
-        boolean result = sut.deleteTodo(todoId, memberId);
+        TodoRequest req = createTodoRequest("내용2", "N", "H", LocalDate.now(), LocalDate.now(), null);
 
-        // Then
-        assertThat(result).isTrue();
-        then(todoRepository).should().deleteByIdAndMember_Sno(todoId, memberId);
+        given(todoRepository.getReferenceById(todo.getId())).willReturn(todo);
+        given(memberRepository.getReferenceById(mismatchMember.getId())).willReturn(mismatchMember);
+
+        // When & Then
+        assertThrows(IllegalArgumentException.class, () -> {
+            todoService.updateTodo(mismatchMember.getId(), todo.getId(), req);
+        });
     }
 
-    @DisplayName("todo 의 ID를 받아, 다음날로 일정을 변경한다.")
+
+    @DisplayName("정상적인 Todo를 삭제 시 true를 반환한다")
     @Test
-    void givenTodoId_whenUpdateDueDate_thenUpdateDueDate() {
+    void givenValidTodoIdAndMemberId_whenDeleteTodo_thenReturnsTrue() {
         // Given
         Long todoId = 1L;
         Long memberId = 1L;
-        LocalDate dueDate = LocalDate.parse("2024-09-06");
-        Todo todo = createTodo();
-        Member member = createMember();
-        TodoRequest req = createTodoRequest(null, null, null, 1, dueDate);
-        given(todoRepository.getReferenceById(todoId)).willReturn(todo);
-        given(memberRepository.getReferenceById(memberId)).willReturn(member);
+
+        given(todoRepository.deleteByIdAndMember_Id(todoId, memberId)).willReturn(1);
+
         // When
-        sut.updateDueDate(memberId, todoId, req);
+        boolean result = todoService.deleteTodo(todoId, memberId);
+
+        // Then
+        assertTrue(result);
+        then(todoRepository).should().deleteByIdAndMember_Id(todoId, memberId);
+    }
+
+    @DisplayName("존재하지 않는 Todo를 삭제 시 false를 반환한다")
+    @Test
+    void givenInvalidTodoIdOrMemberId_whenDeleteTodo_thenReturnsFalse() {
+        // Given
+        Long invalidTodoId = 999L;
+        Long memberId = 1L;
+
+        given(todoRepository.deleteByIdAndMember_Id(invalidTodoId, memberId)).willReturn(0);
+
+        // When
+        boolean result = todoService.deleteTodo(invalidTodoId, memberId);
+
+        // Then
+        assertFalse(result);
+        then(todoRepository).should().deleteByIdAndMember_Id(invalidTodoId, memberId);
+    }
+
+
+    @DisplayName("todo의 ID를 받아, 다음날로 일정을 변경한다.")
+    @Test
+    void givenValidTodoId_whenUpdateDueDate_thenUpdatesDueDate() {
+        // Given
+        Long todoId = 1L;
+        Long memberId = 1L;
+        LocalDate dueDate = LocalDate.of(2024, 9, 6);
+        Member member = createMember(memberId);
+        Todo todo = createTodo(todoId, member);
+
+        TodoRequest req = createTodoRequest(null, null, null, null, null, dueDate.atStartOfDay());
+
+        given(todoRepository.getReferenceById(todoId)).willReturn(todo);
+
+        // When
+        todoService.updateDueDate(memberId, todoId, req);
+
         // Then
         then(todoRepository).should().getReferenceById(todoId);
+        assertEquals(dueDate.atStartOfDay(), todo.getDueDate());
+    }
 
+    @DisplayName("요청한 유저가 작성자가 아니라면 dueDate 수정 시 예외 발생")
+    @Test
+    void givenMismatchedMember_whenUpdateDueDate_thenThrowsException() {
+        // Given
+        Long todoId = 1L;
+        Long memberId = 2L;
+        LocalDate dueDate = LocalDate.of(2024, 9, 6);
 
+        Member originalWriter = createMember(1L);
+        Member otherUser = createMember(2L);
+
+        Todo todo = createTodo(todoId, originalWriter);
+        TodoRequest req = createTodoRequest(null, null, null, null, null, dueDate.atStartOfDay());
+
+        given(todoRepository.getReferenceById(todoId)).willReturn(todo);
+
+        // When & Then
+        assertThrows(IllegalArgumentException.class, () -> {
+            todoService.updateDueDate(memberId, todoId, req);
+        });
     }
 
     private Member createMember() {
-        return Member.of(
-                "najung",
-                "12345",
-                "najung"
+        return createMember(1L);
+    }
 
+    private Member createMember(Long memberId) {
+        Member member = Member.of(
+                "najung",
+                "1q2w3e4r",
+                "najung",
+                "najung@mail.com"
         );
+        ReflectionTestUtils.setField(member, "id", memberId);
+        return member;
     }
 
     private Todo createTodo() {
-        return Todo.of(
-                createMember(),
+        return createTodo(1L, createMember());
+    }
+
+    private Todo createTodo(Long todoId, Member member) {
+        Todo todo = Todo.of(
+                member,
                 "content",
                 "complete",
                 "important",
+                LocalDate.now(),
+                LocalDate.now(),
                 LocalDateTime.parse("2024-09-09T00:00:00")
         );
+        ReflectionTestUtils.setField(todo, "id", todoId);
+
+        return todo;
     }
 
     private TodoRequest createTodoRequest(String content,
                                           String complete,
                                           String important,
-                                          int count,
-                                          LocalDate dueDate) {
+                                          LocalDate startDate,
+                                          LocalDate endDate,
+                                          LocalDateTime dueDate) {
         return TodoRequest.of(
                 content,
                 complete,
                 important,
-                dueDate,
-                count
+                startDate,
+                endDate,
+                dueDate
+
         );
 
     }
 
-    private TodoDto createTodoDto(String content, String complete, String important, LocalDateTime dueDate) {
+
+    private TodoDto createTodoDto(String content, String complete, String important, LocalDate startDate, LocalDate endDate, LocalDateTime dueDate) {
         return TodoDto.of(
                 createUserDto(),
                 content,
                 complete,
                 important,
+                startDate,
+                endDate,
                 dueDate
+        );
+    }
+
+    private TodoSearchRequest createSearchRequest(String keyword, String completed, String important,
+                                                  LocalDate startDate, LocalDate endDate) {
+        TodoSearchRequest request = new TodoSearchRequest();
+        ReflectionTestUtils.setField(request, "keyword", keyword);
+        ReflectionTestUtils.setField(request, "completed", completed);
+        ReflectionTestUtils.setField(request, "important", important);
+        ReflectionTestUtils.setField(request, "startDate", startDate);
+        ReflectionTestUtils.setField(request, "endDate", endDate);
+        return request;
+    }
+
+    private TodoSearchRequest createDefaultSearchRequest() {
+        return createSearchRequest(
+                "공부",
+                "Y",
+                "H",
+                LocalDate.now().minusDays(7),
+                LocalDate.now()
         );
     }
 


### PR DESCRIPTION
 - 기존 의미없이 반복 추가만 하던 로직 삭제 -> 시작일과 종료일을 받아 해당 범위 안에서 반복 저장이 가능하게끔 수정 TodoController
 - service의 수정에 따른 불필요 컨트롤러 메서드 제거 Todo, TodoDto, TodoRequest
 - startDate, endDate 추가 TodoServiceTest
 - TodoService 저장, 수정, 삭제, 조회 로직 단위 테스트 작성